### PR TITLE
Add documentation to the full API

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,1 @@
+--no-private

--- a/.yardopts
+++ b/.yardopts
@@ -1,1 +1,1 @@
---no-private
+--no-private --embed-mixins

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # WordpressClient
 
-WordpressClient is a very simple client to the Wordpress API, version 2 beta 8.0.
+WordpressClient is a very simple client for the Wordpress [WP REST API plugin][api] (version 2 beta 8.0).
 
 [![Circle CI](https://circleci.com/gh/hemnet/wordpress_client.svg?style=svg)](https://circleci.com/gh/hemnet/wordpress_client) [![Code Climate](https://codeclimate.com/repos/5645938269568041da00cded/badges/5e870b57428f23c1f2ff/gpa.svg)](https://codeclimate.com/repos/5645938269568041da00cded/feed) [![Test Coverage](https://codeclimate.com/repos/5645938269568041da00cded/badges/5e870b57428f23c1f2ff/coverage.svg)](https://codeclimate.com/repos/5645938269568041da00cded/coverage) [![Gem Version](https://badge.fury.io/rb/wordpress_client.svg)](https://badge.fury.io/rb/wordpress_client)
 
 ## Usage
 
-Initialize a client with a username, password and API URL. You can then search for posts.
+**[Read the full API documentation][docs]**
+
+Initialize a client with a user name, password and API URL. You can then search for posts.
 
 ```ruby
 client = WordpressClient.new(url: "https://example.com/wp-json/", username: "example", password: "example")
@@ -33,8 +35,6 @@ updated_post.title_html # => "Updated"
 ## Running tests
 
 You need to install Docker and set it up for your machine. Note that you need `docker-machine` to run Docker on OS X.
-
-Then build the docker image using `rake docker:build`.
 
 Run tests using the normal `rspec` command after installing all bundles.
 
@@ -67,3 +67,6 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+[api]: http://v2.wp-api.org/
+[docs]: http://www.rubydoc.info/gems/wordpress_client/

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,8 @@
 require "bundler/gem_tasks"
+require "yard"
+require "wordpress_client/version"
+
+YARD::Rake::YardocTask.new
 
 namespace :docker do
   DOCKER_DIR = File.expand_path("../spec/docker", __FILE__).freeze

--- a/lib/wordpress_client.rb
+++ b/lib/wordpress_client.rb
@@ -19,7 +19,26 @@ require "wordpress_client/replace_terms"
 require "wordpress_client/replace_metadata"
 
 module WordpressClient
-  def self.new(*args)
-    Client.new(Connection.new(*args))
+  # Initialize a new client using the provided connection details.
+  # You need to provide authentication details, and the user must have +edit+
+  # permissions on the blog if you want to read Post Meta, or to modify
+  # anything.
+  #
+  # @example
+  #   client = WordpressClient.new(
+  #     url: "https://blog.example.com/wp-json",
+  #     username: "bot",
+  #     password: ENV.fetch("WORDPRESS_PASSWORD"),
+  #   )
+  #
+  # @see Client Client, for the methods available after creating the connection.
+  #
+  # @param url [String] The base URL to the wordpress install, including
+  #                     +/wp-json+.
+  # @param username [String] A valid username on the wordpress installation.
+  # @param password [String] The password for the provided user.
+  # @return {Client}
+  def self.new(url:, username:, password:)
+    Client.new(Connection.new(url: url, username: username, password: password))
   end
 end

--- a/lib/wordpress_client/category.rb
+++ b/lib/wordpress_client/category.rb
@@ -1,4 +1,6 @@
 module WordpressClient
+  # Represents a category from Wordpress.
+  # @see Term
   class Category < Term
   end
 end

--- a/lib/wordpress_client/client.rb
+++ b/lib/wordpress_client/client.rb
@@ -189,36 +189,110 @@ module WordpressClient
 
     # @!group Tags
 
+    # Find {Tag Tags} in the Wordpress install.
+    #
+    # @return {PaginatedCollection[Tag]}
     def tags(per_page: 10, page: 1)
       connection.get_multiple(Tag, "terms/tag", page: page, per_page: per_page)
     end
 
+    # Find {Tag} with the given ID.
+    #
+    # @return {Tag}
+    # @raise {NotFoundError}
     def find_tag(id)
       connection.get(Tag, "terms/tag/#{id.to_i}")
     end
 
+    # Create a new {Tag} with the given attributes.
+    #
+    # @see http://v2.wp-api.org/reference/taxonomies/ List of accepted parameters
+    # @param attributes [Hash<Symbol,Object>] attribute list, containing
+    #                   parameters accepted by the API.
+    # @option attributes [String] name Name of the tag (required).
+    # @option attributes [String] slug Slug of the tag (optional).
+    # @option attributes [String] description Description of the tag (optional).
+    #
+    # @return {Tag} the new Tag
+    # @raise {ValidationError}
     def create_tag(attributes)
       connection.create(Tag, "terms/tag", attributes)
     end
 
+    # Update the {Tag} with the given id, setting the supplied attributes.
+    #
+    # @see http://v2.wp-api.org/reference/taxonomies/ List of accepted parameters
+    # @param attributes [Hash<Symbol,Object>] attribute list, containing
+    #                   parameters accepted by the API.
+    # @option attributes [String] name Name of the tag.
+    # @option attributes [String] slug Slug of the tag.
+    # @option attributes [String] description Description of the tag.
+    #
+    # @return {Tag} the updated Tag
+    # @raise {NotFoundError}
+    # @raise {ValidationError}
     def update_tag(id, attributes)
       connection.patch(Tag, "terms/tag/#{id.to_i}", attributes)
     end
 
     # @!group Media
 
+    # Find {Media} in the Wordpress install.
+    #
+    # @return {PaginatedCollection[Media]}
     def media(per_page: 10, page: 1)
       connection.get_multiple(Media, "media", page: page, per_page: per_page)
     end
 
+    # Find {Media} with the given ID.
+    #
+    # @return {Media}
+    # @raise {NotFoundError}
     def find_media(id)
       connection.get(Media, "media/#{id.to_i}")
     end
 
+    # Create a new {Media} by uploading a IO stream.
+    #
+    # You need to provide both MIME type and filename for Wordpress to accept
+    # the file.
+    #
+    # @example Uploading a JPEG from a request
+    #   media = client.upload(
+    #     request.body_stream, filename: "foo.jpg", mime_type: "image/jpeg"
+    #   )
+    #
+    # @param io [IO-like object] IO stream (for example an open file) that will
+    #        be the body of the media.
+    # @param mime_type [String] the MIME type of the IO stream
+    # @param filename [String] the filename that Wordpress should see. Requires
+    #        a file extension to make Wordpress happy.
+    #
+    # @return {Media} the new Media
+    # @raise {ValidationError}
+    # @see #upload_file #upload_file - a shortcut for uploading files on disk
     def upload(io, mime_type:, filename:)
       connection.upload(Media, "media", io, mime_type: mime_type, filename: filename)
     end
 
+    # Create a new {Media} by uploading a file from disk.
+    #
+    # You need to provide MIME type for Wordpress to accept the file. The
+    # filename that Wordpress sees will automatically be derived from the
+    # passed path.
+    #
+    # @example Uploading a JPEG from disk
+    #   media = client.upload_file(
+    #     "assets/ocean.jpg", mime_type: "image/jpeg"
+    #   )
+    #
+    # @param filename [String] a path to a readable file.
+    # @param mime_type [String] the MIME type of the file.
+    #
+    # @return {Media} the new Media
+    # @raise {ValidationError}
+    # @see #upload #upload - for when you want to upload something that isn't a
+    #              file on disk, or need extra flexibility
     def upload_file(filename, mime_type:)
       path = filename.to_s
       File.open(path, 'r') do |file|
@@ -226,6 +300,15 @@ module WordpressClient
       end
     end
 
+    # Update the {Media} with the given id, setting the supplied attributes.
+    #
+    # @see http://v2.wp-api.org/reference/media/ List of accepted parameters
+    # @param attributes [Hash<Symbol,Object>] attribute list, containing
+    #                   parameters accepted by the API.
+    #
+    # @return {Media} The updated Media
+    # @raise {NotFoundError}
+    # @raise {ValidationError}
     def update_media(id, attributes)
       connection.patch(Media, "media/#{id.to_i}", attributes)
     end

--- a/lib/wordpress_client/client.rb
+++ b/lib/wordpress_client/client.rb
@@ -4,6 +4,8 @@ module WordpressClient
       @connection = connection
     end
 
+    # @!group Posts
+
     def posts(per_page: 10, page: 1, category_slug: nil, tag_slug: nil)
       filter = {}
       filter[:category_name] = category_slug if category_slug
@@ -11,18 +13,6 @@ module WordpressClient
       connection.get_multiple(
         Post, "posts", per_page: per_page, page: page, _embed: nil, context: "edit", filter: filter
       )
-    end
-
-    def categories(per_page: 10, page: 1)
-      connection.get_multiple(Category, "terms/category", page: page, per_page: per_page)
-    end
-
-    def tags(per_page: 10, page: 1)
-      connection.get_multiple(Tag, "terms/tag", page: page, per_page: per_page)
-    end
-
-    def media(per_page: 10, page: 1)
-      connection.get_multiple(Media, "media", page: page, per_page: per_page)
     end
 
     def find_post(id)
@@ -40,18 +30,6 @@ module WordpressClient
       end
     end
 
-    def find_category(id)
-      connection.get(Category, "terms/category/#{id.to_i}")
-    end
-
-    def find_tag(id)
-      connection.get(Tag, "terms/tag/#{id.to_i}")
-    end
-
-    def find_media(id)
-      connection.get(Media, "media/#{id.to_i}")
-    end
-
     def create_post(attributes)
       post = connection.create(Post, "posts", attributes, redirect_params: {_embed: nil})
 
@@ -65,14 +43,6 @@ module WordpressClient
       else
         post
       end
-    end
-
-    def create_category(attributes)
-      connection.create(Category, "terms/category", attributes)
-    end
-
-    def create_tag(attributes)
-      connection.create(Tag, "terms/tag", attributes)
     end
 
     def update_post(id, attributes)
@@ -90,16 +60,54 @@ module WordpressClient
       end
     end
 
+    def delete_post(id, force: false)
+      connection.delete("posts/#{id.to_i}", {"force" => force})
+    end
+
+    # @!group Categories
+
+    def categories(per_page: 10, page: 1)
+      connection.get_multiple(Category, "terms/category", page: page, per_page: per_page)
+    end
+
+    def find_category(id)
+      connection.get(Category, "terms/category/#{id.to_i}")
+    end
+
+    def create_category(attributes)
+      connection.create(Category, "terms/category", attributes)
+    end
+
     def update_category(id, attributes)
       connection.patch(Category, "terms/category/#{id.to_i}", attributes)
+    end
+
+    # @!group Tags
+
+    def tags(per_page: 10, page: 1)
+      connection.get_multiple(Tag, "terms/tag", page: page, per_page: per_page)
+    end
+
+    def find_tag(id)
+      connection.get(Tag, "terms/tag/#{id.to_i}")
+    end
+
+    def create_tag(attributes)
+      connection.create(Tag, "terms/tag", attributes)
     end
 
     def update_tag(id, attributes)
       connection.patch(Tag, "terms/tag/#{id.to_i}", attributes)
     end
 
-    def update_media(id, attributes)
-      connection.patch(Media, "media/#{id.to_i}", attributes)
+    # @!group Media
+
+    def media(per_page: 10, page: 1)
+      connection.get_multiple(Media, "media", page: page, per_page: per_page)
+    end
+
+    def find_media(id)
+      connection.get(Media, "media/#{id.to_i}")
     end
 
     def upload(io, mime_type:, filename:)
@@ -113,9 +121,11 @@ module WordpressClient
       end
     end
 
-    def delete_post(id, force: false)
-      connection.delete("posts/#{id.to_i}", {"force" => force})
+    def update_media(id, attributes)
+      connection.patch(Media, "media/#{id.to_i}", attributes)
     end
+
+    # @!endgroup
 
     def inspect
       "#<WordpressClient::Client #{connection.inspect}>"

--- a/lib/wordpress_client/client.rb
+++ b/lib/wordpress_client/client.rb
@@ -6,7 +6,7 @@ module WordpressClient
 
     # @!group Posts
 
-    # Find posts matching given parameters.
+    # Find {Post Posts} matching given parameters.
     #
     # @example Finding 5 posts in the Important category
     #   posts = client.posts(per_page: 5, category_slug: "important")
@@ -26,18 +26,20 @@ module WordpressClient
       )
     end
 
-    # Find the post with the given ID, or raises an error if it cannot be found.
+    # Find the {Post} with the given ID, or raises an error if not found.
     #
     # @return {Post}
     # @raise {NotFoundError}
+    # @raise {subclasses of Error} on other unexpected errors
     def find_post(id)
       connection.get(Post, "posts/#{id.to_i}", _embed: nil, context: "edit")
     end
 
-    # Find the first post with the given slug, or raises an error if it cannot be found.
+    # Find the first {Post} with the given slug, or raises an error if it cannot be found.
     #
     # @return {Post}
     # @raise {NotFoundError}
+    # @raise {subclasses of Error} on other unexpected errors
     def find_post_by_slug(slug)
       posts = connection.get_multiple(
         Post, "posts", per_page: 1, page: 1, filter: {name: slug}, _embed: nil
@@ -69,6 +71,7 @@ module WordpressClient
     #
     # @return {Post}
     # @raise {ValidationError}
+    # @raise {subclasses of Error} on other unexpected errors
     def create_post(attributes)
       post = connection.create(Post, "posts", attributes, redirect_params: {_embed: nil})
 
@@ -111,6 +114,7 @@ module WordpressClient
     # @return {Post}
     # @raise {NotFoundError}
     # @raise {ValidationError}
+    # @raise {subclasses of Error} on other unexpected errors
     def update_post(id, attributes)
       post = connection.patch(Post, "posts/#{id.to_i}?_embed", attributes)
 
@@ -150,6 +154,7 @@ module WordpressClient
     #
     # @return {Category}
     # @raise {NotFoundError}
+    # @raise {subclasses of Error} on other unexpected errors
     def find_category(id)
       connection.get(Category, "terms/category/#{id.to_i}")
     end
@@ -165,6 +170,7 @@ module WordpressClient
     #
     # @return {Category} the new Category
     # @raise {ValidationError}
+    # @raise {subclasses of Error} on other unexpected errors
     def create_category(attributes)
       connection.create(Category, "terms/category", attributes)
     end
@@ -181,6 +187,7 @@ module WordpressClient
     # @return {Category} the updated Category
     # @raise {NotFoundError}
     # @raise {ValidationError}
+    # @raise {subclasses of Error} on other unexpected errors
     def update_category(id, attributes)
       connection.patch(Category, "terms/category/#{id.to_i}", attributes)
     end
@@ -198,6 +205,7 @@ module WordpressClient
     #
     # @return {Tag}
     # @raise {NotFoundError}
+    # @raise {subclasses of Error} on other unexpected errors
     def find_tag(id)
       connection.get(Tag, "terms/tag/#{id.to_i}")
     end
@@ -213,6 +221,7 @@ module WordpressClient
     #
     # @return {Tag} the new Tag
     # @raise {ValidationError}
+    # @raise {subclasses of Error} on other unexpected errors
     def create_tag(attributes)
       connection.create(Tag, "terms/tag", attributes)
     end
@@ -229,6 +238,7 @@ module WordpressClient
     # @return {Tag} the updated Tag
     # @raise {NotFoundError}
     # @raise {ValidationError}
+    # @raise {subclasses of Error} on other unexpected errors
     def update_tag(id, attributes)
       connection.patch(Tag, "terms/tag/#{id.to_i}", attributes)
     end
@@ -246,6 +256,7 @@ module WordpressClient
     #
     # @return {Media}
     # @raise {NotFoundError}
+    # @raise {subclasses of Error} on other unexpected errors
     def find_media(id)
       connection.get(Media, "media/#{id.to_i}")
     end
@@ -268,6 +279,7 @@ module WordpressClient
     #
     # @return {Media} the new Media
     # @raise {ValidationError}
+    # @raise {subclasses of Error} on other unexpected errors
     # @see #upload_file #upload_file - a shortcut for uploading files on disk
     def upload(io, mime_type:, filename:)
       connection.upload(Media, "media", io, mime_type: mime_type, filename: filename)
@@ -289,6 +301,7 @@ module WordpressClient
     #
     # @return {Media} the new Media
     # @raise {ValidationError}
+    # @raise {subclasses of Error} on other unexpected errors
     # @see #upload #upload - for when you want to upload something that isn't a
     #              file on disk, or need extra flexibility
     def upload_file(filename, mime_type:)
@@ -307,6 +320,7 @@ module WordpressClient
     # @return {Media} The updated Media
     # @raise {NotFoundError}
     # @raise {ValidationError}
+    # @raise {subclasses of Error} on other unexpected errors
     def update_media(id, attributes)
       connection.patch(Media, "media/#{id.to_i}", attributes)
     end

--- a/lib/wordpress_client/connection.rb
+++ b/lib/wordpress_client/connection.rb
@@ -2,6 +2,7 @@ require "faraday"
 require "json"
 
 module WordpressClient
+  # @private
   class Connection
     attr_reader :url, :username
 

--- a/lib/wordpress_client/errors.rb
+++ b/lib/wordpress_client/errors.rb
@@ -30,7 +30,7 @@ module WordpressClient
   # Raised when trying to find a resource that doesn't exist. It will also
   # happen when you try to update a resource that doesn't exist.
   #
-  # Lack of authorization could also mask actual resources so it appears that
+  # Lack of authorization can also mask actual resources so it appears that
   # they don't exist.
   #
   # @see Error

--- a/lib/wordpress_client/errors.rb
+++ b/lib/wordpress_client/errors.rb
@@ -1,10 +1,45 @@
 module WordpressClient
-  Error = Class.new(::StandardError)
+  # Base class for all errors emitted from this gem. Rescue this in order to
+  # catch everything.
+  #
+  # See the list of subclasses for more specific error types.
+  class Error < ::StandardError; end
 
-  UnauthorizedError = Class.new(Error)
+  # Raised when the clients attempt to do something that the user isn't
+  # authorized to do.
+  #
+  # This could happen if you try to delete a post and the user only has
+  # read-only access, for example.
+  # It would also happen if you provide bad authentication details.
+  #
+  # @see Error
+  class UnauthorizedError < Error; end
 
-  TimeoutError = Class.new(Error)
-  ServerError = Class.new(Error)
-  NotFoundError = Class.new(Error)
-  ValidationError = Class.new(Error)
+  # Raised when a request times out.
+  #
+  # @see Error
+  class TimeoutError < Error; end
+
+  # Raised when the server had an error, or when the server returned something
+  # unexpected, despite saying everything went okay. It's the most generic
+  # "Something went wrong with the request" error.
+  #
+  # @see Error
+  class ServerError < Error; end
+
+  # Raised when trying to find a resource that doesn't exist. It will also
+  # happen when you try to update a resource that doesn't exist.
+  #
+  # Lack of authorization could also mask actual resources so it appears that
+  # they don't exist.
+  #
+  # @see Error
+  class NotFoundError < Error; end
+
+  # Raised when the server rejects the body of a request. The error message
+  # will often include information about why the body was rejected, but it is
+  # not guaranteed.
+  #
+  # @see Error
+  class ValidationError < Error; end
 end

--- a/lib/wordpress_client/media.rb
+++ b/lib/wordpress_client/media.rb
@@ -1,4 +1,5 @@
 module WordpressClient
+  # Represents a media record in Wordpress.
   class Media
     attr_accessor(
       :id, :slug, :title_html, :description,
@@ -6,10 +7,41 @@ module WordpressClient
       :guid, :link, :media_details
     )
 
+    # @!attribute [rw] title_html
+    #   @return [String] the title of the media, HTML escaped
+    #   @example
+    #     media.title_html #=> "Sunset &mdash; Painting by some person"
+
+    # @!attribute [rw] date
+    #   @return [Time, nil] the date of the media, in UTC if available
+
+    # @!attribute [rw] updated_at
+    #   @return [Time, nil] the modification date of the media, in UTC if available
+
+    # @!attribute [rw] guid
+    #   Returns the permalink/GUID – or +source_url+ – of the media.
+    #
+    #   Media that are embedded in posts have a +source_url+ attribute and no
+    #   +guid+, and stand-alone media has a +guid+ but no +source_url+. They
+    #   are both backed by the same data, so this method handles both cases,
+    #   and is aliased to both names.
+    #
+    #   @return [String] the permalink/GUID – or +source_url+ – of the media
+
+    # @!attribute [rw] media_details
+    #   Returns the media details if available.
+    #
+    #   Media details cannot be documented here. It's up to you to handle this
+    #   generic "payload" attribute the best way you can.
+    #
+    #   @return [Hash<String,Object>] the media details returned from the server
+
+    # @api private
     def self.parse(data)
       MediaParser.parse(data)
     end
 
+    # Creates a new instance, populating the fields with the passed values.
     def initialize(
       id: nil,
       slug: nil,

--- a/lib/wordpress_client/media_parser.rb
+++ b/lib/wordpress_client/media_parser.rb
@@ -1,4 +1,5 @@
 module WordpressClient
+  # @private
   class MediaParser
     include RestParser
 

--- a/lib/wordpress_client/paginated_collection.rb
+++ b/lib/wordpress_client/paginated_collection.rb
@@ -1,9 +1,31 @@
 require "delegate"
 
 module WordpressClient
+  # Represents a paginated list of resources.
+  #
+  # @note This class has the full +Array+ interface by using
+  #       +DelegateClass(Array)+. Methods do not show up in the documentation
+  #       unless when manually documented.
   class PaginatedCollection < DelegateClass(Array)
+    # @!method size
+    #   @return [Fixnum] the number of records actually in this "page".
+    #   @see Array#size
+
     attr_reader :total, :current_page, :per_page
 
+    # @!attribute [r] total
+    #   @return [Fixnum] the total hits in the full collection.
+    #   @see #size #size is the size of the current "page".
+
+    # @!attribute [r] current_page
+    #   @return [Fixnum] the current page number, where +1+ is the first page.
+
+    # @!attribute [r] per_page
+    #   @return [Fixnum] the current page size setting, for example +30+.
+
+    # Create a new collection using the passed array +entries+.
+    #
+    # @param entries [Array] the original "page" array
     def initialize(entries, total:, current_page:, per_page:)
       super(entries)
       @total = total
@@ -11,12 +33,15 @@ module WordpressClient
       @per_page = per_page
     end
 
-    #
-    # Pagination methods. Fulfilling will_paginate protocol
-    #
+    # @!group will_paginate protocol
 
     alias total_entries total
 
+    # @note This method is used by +will_paginate+. By implementing this
+    #       interface, you can use a {PaginatedCollection} in place of a
+    #       +WillPaginate::Collection+ to render pagination details.
+    # @return [Fixnum] the total number of pages that can show the {#total}
+    #         entries with {#per_page} records per page. +0+ if no entries.
     def total_pages
       if total.zero? || per_page.zero?
         0
@@ -25,23 +50,53 @@ module WordpressClient
       end
     end
 
+    # @note This method is used by +will_paginate+. By implementing this
+    #       interface, you can use a {PaginatedCollection} in place of a
+    #       +WillPaginate::Collection+ to render pagination details.
+    # @return [Fixnum, nil] the next page number or +nil+ if on last page.
     def next_page
       if current_page < total_pages
         current_page + 1
       end
     end
 
+    # @note This method is used by +will_paginate+. By implementing this
+    #       interface, you can use a {PaginatedCollection} in place of a
+    #       +WillPaginate::Collection+ to render pagination details.
+    # @return [Fixnum, nil] the previous page number or +nil+ if on first page.
     def previous_page
       if current_page > 1
         current_page - 1
       end
     end
 
+    # @note This method is used by +will_paginate+. By implementing this
+    #       interface, you can use a {PaginatedCollection} in place of a
+    #       +WillPaginate::Collection+ to render pagination details.
+    # @return [Boolean] if the current page is out of bounds, e.g. less than 1
+    #                   or higher than {#total_pages}.
     def out_of_bounds?
       current_page < 1 || current_page > total_pages
     end
 
-    # will_paginate < 3.0 has this method
+    # @note This method is used by +will_paginate+. By implementing this
+    #       interface, you can use a {PaginatedCollection} in place of a
+    #       +WillPaginate::Collection+ to render pagination details.
+    #
+    # @note will_paginate < 3.0 has this method, but it's no longer present in
+    #       newer will_paginate.
+    #
+    # Returns the offset of the current page.
+    #
+    # @example First page offset
+    #   collection.per_page # => 20
+    #   collection.current_page # => 1
+    #   collection.offset #=> 0
+    # @example Later offset
+    #   collection.per_page # => 20
+    #   collection.current_page # => 3
+    #   collection.offset #=> 40
+    #
     def offset
       if current_page > 0
         (current_page - 1) * per_page
@@ -49,5 +104,7 @@ module WordpressClient
         0
       end
     end
+
+    # @!endgroup
   end
 end

--- a/lib/wordpress_client/post.rb
+++ b/lib/wordpress_client/post.rb
@@ -1,6 +1,9 @@
 require "time"
 
 module WordpressClient
+  # Represents a post in Wordpress.
+  #
+  # @see http://v2.wp-api.org/reference/posts/ API documentation for Post
   class Post
     attr_accessor(
       :id, :slug, :url, :guid, :status,
@@ -9,10 +12,60 @@ module WordpressClient
       :categories, :tags, :meta, :featured_image
     )
 
+    # @!attribute [rw] title_html
+    #   @return [String] the title of the media, HTML escaped
+    #   @example
+    #     post.title_html #=> "Fire &amp; diamonds!"
+
+    # @!attribute [rw] date
+    #   @return [Time, nil] the date of the post, in UTC if available
+
+    # @!attribute [rw] updated_at
+    #   @return [Time, nil] the modification date of the post, in UTC if available
+
+    # @!attribute [rw] guid
+    #   @return [String] the permalink/GUID of the post for internal addressing
+    #   @see #url
+
+    # @!attribute [rw] url
+    #   @return [String] the URL (link) to the post
+
+    # @!attribute [rw] status
+    #   @return ["publish", "future", "draft", "pending", "private", nil] the
+    #           current status of the post, or +nil+ if undetermined
+
+    # @!attribute [rw] categories
+    #   @return [Array[Category]] the {Category Categories} the post belongs to.
+    #   @see Category
+
+    # @!attribute [rw] tags
+    #   @return [Array[Tag]] the {Tag Tags} the post belongs to.
+    #   @see Tag
+
+    # @!attribute [rw] featured_image
+    #   @return [Media, nil] the featured image, as an instance of {Media}
+    #   @see Media
+
+    # @!attribute [rw] meta
+    #   Returns the Post meta, as a +Hash+ of +String => String+.
+    #
+    #   @example
+    #     post.meta # => {"Mood" => "Happy", "reviewed_by" => "user:45"}
+    #
+    #   @return [Hash<String,String>] the post meta, as a Hash.
+    #   @see Category
+    #   @see Client#update_post
+
+    # @!attribute [rw] meta_ids
+    #   @api private
+    #   Backs the {#meta_id_for} method. Used when constructing requests.
+
+    # @api private
     def self.parse(data)
       PostParser.parse(data)
     end
 
+    # Construct a new instance with the given attributes.
     def initialize(
       id: nil,
       slug: nil,
@@ -47,14 +100,32 @@ module WordpressClient
       @meta_ids = meta_ids
     end
 
+    # A list of all category ids for the post.
+    #
+    # You can pass this list, with IDs added or removed, to
+    # {Client#update_post} to change the category list.
+    #
+    # @return [Array[Fixnum]] the id of every category associated with this post
+    # @see Client#update_post
     def category_ids() categories.map(&:id) end
 
+    # A list of all tag ids for the post.
+    #
+    # You can pass this list, with IDs added or removed, to
+    # {Client#update_post} to change the tag list.
+    #
+    # @return [Array[Fixnum]] the id of every tag associated with this post
+    # @see Client#update_post
     def tag_ids() tags.map(&:id) end
 
+    # @return [Fixnum, nil] ID of the featured image associated with the post.
     def featured_image_id
       featured_image && featured_image.id
     end
 
+    # @api private
+    # Used to determine the underlying ID of the different meta keys so they
+    # can be modified by {Client}. You should not use this for anything.
     def meta_id_for(key)
       @meta_ids[key] || raise(ArgumentError, "Post does not have meta #{key.inspect}")
     end

--- a/lib/wordpress_client/post_parser.rb
+++ b/lib/wordpress_client/post_parser.rb
@@ -1,4 +1,5 @@
 module WordpressClient
+  # @private
   class PostParser
     include RestParser
 

--- a/lib/wordpress_client/replace_metadata.rb
+++ b/lib/wordpress_client/replace_metadata.rb
@@ -1,6 +1,7 @@
 require "set"
 
 module WordpressClient
+  # @private
   class ReplaceMetadata
     def self.apply(connection, post, meta)
       instance = new(connection, post, meta)

--- a/lib/wordpress_client/replace_terms.rb
+++ b/lib/wordpress_client/replace_terms.rb
@@ -1,6 +1,7 @@
 require "set"
 
 module WordpressClient
+  # @private
   class ReplaceTerms
     def self.apply_categories(connection, post, category_ids)
       instance = new(

--- a/lib/wordpress_client/rest_parser.rb
+++ b/lib/wordpress_client/rest_parser.rb
@@ -1,4 +1,8 @@
 module WordpressClient
+  # @private
+  #
+  # Module included in other classes that need to parse result bodies from the
+  # WP API.
   module RestParser
     private
     def rendered(name)

--- a/lib/wordpress_client/tag.rb
+++ b/lib/wordpress_client/tag.rb
@@ -1,4 +1,6 @@
 module WordpressClient
+  # Represents a tag from Wordpress.
+  # @see Term
   class Tag < Term
   end
 end

--- a/lib/wordpress_client/term.rb
+++ b/lib/wordpress_client/term.rb
@@ -1,7 +1,27 @@
 module WordpressClient
+  # @abstract Implement a subclass for the resource type.
+  #
+  # Implementation for the abstract "term" in Wordpress.
+  #
+  # @see Category
+  # @see Tag
   class Term
     attr_reader :id, :name_html, :slug
 
+    # @!attribute [r] id
+    #   @return [Fixnum] The ID of the resource in Wordpress.
+
+    # @!attribute [r] name_html
+    #   @return [String] The name of the resource, HTML encoded.
+    #   @example
+    #     term.name_html #=> "Father &amp; Daughter stuff"
+
+    # @!attribute [r] slug
+    #   @return [String] The slug of the resource in Wordpress.
+
+    # @api private
+    #
+    # Parses a data structure from a WP API response body into this term type.
     def self.parse(data)
       new(
         id: data.fetch("id"),
@@ -16,6 +36,15 @@ module WordpressClient
       @slug = slug
     end
 
+    # @api private
+    # Compares another instance. All attributes in this list must be equal for
+    # the instances to be equal:
+    #
+    # * +id+
+    # * +name_html+
+    # * +slug+
+    #
+    # One must also not be a subclass of the other; they must be the exact same class.
     def ==(other)
       if other.is_a? Term
         other.class == self.class &&
@@ -27,6 +56,7 @@ module WordpressClient
       end
     end
 
+    # Shows a nice representation of the term type.
     def inspect
       "#<#{self.class} ##{id} #{name_html.inspect} (#{slug})>"
     end

--- a/lib/wordpress_client/version.rb
+++ b/lib/wordpress_client/version.rb
@@ -1,3 +1,7 @@
 module WordpressClient
+  # Current version of the gem.
+  #
+  # @note This only applies if using a released version. A development build
+  #       would not correspond to this constant.
   VERSION = "0.0.1"
 end

--- a/wordpress_client.gemspec
+++ b/wordpress_client.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.3"
   spec.add_development_dependency "webmock", "~> 1.22"
+  spec.add_development_dependency "yard", "~> 0.8.7"
 end


### PR DESCRIPTION
This is a work-in-progress PR for documenting the entire gem. Any code changes discovered here will be marked with `@todo` so we keep this branch to documentation changes only.

**Note:** You can read the rendered documentation locally by installing dependencies, then running `yard server --reload`.
`rake yard` will build it once.

**Current list of `@todo`s so far:**
- [x] `Client#find_by_slug` should be renamed to `#find_post_by_slug` <del>(#23)</del>

CC @rmeritz @kolizz 