### PR TITLE
Rename Client#find_by_slug → #find_post_by_slug

### DIFF
--- a/lib/wordpress_client/client.rb
+++ b/lib/wordpress_client/client.rb
@@ -29,7 +29,7 @@ module WordpressClient
       connection.get(Post, "posts/#{id.to_i}", _embed: nil, context: "edit")
     end
 
-    def find_by_slug(slug)
+    def find_post_by_slug(slug)
       posts = connection.get_multiple(
         Post, "posts", per_page: 1, page: 1, filter: {name: slug}, _embed: nil
       )

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -66,7 +66,7 @@ module WordpressClient
           Post, "posts", hash_including(filter: {name: "my-slug"})
         ).and_return [post]
 
-        expect(client.find_by_slug("my-slug")).to eq post
+        expect(client.find_post_by_slug("my-slug")).to eq post
       end
 
       it "raises NotFoundError when trying to find by slug yields no posts" do
@@ -75,7 +75,7 @@ module WordpressClient
         ).and_return []
 
         expect {
-          client.find_by_slug("my-slug")
+          client.find_post_by_slug("my-slug")
         }.to raise_error(NotFoundError, /my-slug/)
       end
     end

--- a/spec/integration/posts_finding_spec.rb
+++ b/spec/integration/posts_finding_spec.rb
@@ -64,13 +64,13 @@ describe "Posts (finding)" do
   describe "finding by slug" do
     it "finds the matching post" do
       post = client.create_post(title: "Oh hai", slug: "oh-hai")
-      found = client.find_by_slug("oh-hai")
+      found = client.find_post_by_slug("oh-hai")
       expect(found.id).to eq post.id
     end
 
     it "raises NotFoundError when no post can be found" do
       expect {
-        client.find_by_slug("clearly-does-not-exist-anywhere")
+        client.find_post_by_slug("clearly-does-not-exist-anywhere")
       }.to raise_error(WordpressClient::NotFoundError, /clearly/)
     end
 
@@ -79,7 +79,7 @@ describe "Posts (finding)" do
         title: "Updated title that doesn't match slug",
         slug: "original-concise-title",
       )
-      found = client.find_by_slug("original-concise-title")
+      found = client.find_post_by_slug("original-concise-title")
       expect(found.id).to eq post.id
     end
   end


### PR DESCRIPTION
It makes a lot more sense.
See #22.