### PR TITLE
Update Codeclimate and Rubocop configs

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,12 +1,27 @@
----
 engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - ruby
   rubocop:
+    enabled: true
+  brakeman:
+    enabled: true
+  bundler-audit:
     enabled: true
   fixme:
     enabled: true
+    config:
+      strings:
+      - FIXME
+      - TODO
 ratings:
   paths:
-  - lib/**/*.rb
+  - Gemfile.lock
+  - lib/**
+  - "**.rb"
 exclude_paths:
-- spec/**/*
-- ".*"
+  - doc/**/*
+  - spec/**/*
+  - tmp/**/*

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -6,8 +6,6 @@ engines:
       - ruby
   rubocop:
     enabled: true
-  brakeman:
-    enabled: true
   bundler-audit:
     enabled: true
   fixme:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -6,8 +6,6 @@ engines:
       - ruby
   rubocop:
     enabled: true
-  bundler-audit:
-    enabled: true
   fixme:
     enabled: true
     config:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  TargetRubyVersion: 2.2
   Include:
   - "**/*.gemspec"
   - "**/*.podspec"
@@ -15,12 +16,10 @@ AllCops:
   - "**/Berksfile"
   - "**/Cheffile"
   - "**/Vagabondfile"
-  Exclude:
-  - "vendor/**/*"
-  - "db/schema.rb"
-  RunRailsCops: false
   DisplayCopNames: false
   StyleGuideCopsOnly: false
+Rails:
+  Enabled: false
 Style/AccessModifierIndentation:
   Description: Check indentation of private/protected visibility modifiers.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#indent-public-private-protected
@@ -275,7 +274,7 @@ Style/MultilineOperationIndentation:
 Style/NumericLiterals:
   Description: Add underscores to large numeric literals to improve their readability.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#underscores-in-numerics
-  Enabled: false
+  Enabled: true
   MinDigits: 5
 Style/ParenthesesAroundCondition:
   Description: Don't use parentheses around the condition of an if/unless/while.
@@ -432,14 +431,14 @@ Style/TrailingBlankLines:
   SupportedStyles:
   - final_newline
   - final_blank_line
-Style/TrailingComma:
-  Description: Checks for trailing comma in parameter lists and literals.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
+Style/TrailingCommaInArguments:
+  Description: 'Checks for trailing comma in argument lists.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
   Enabled: false
-  EnforcedStyleForMultiline: no_comma
-  SupportedStyles:
-  - comma
-  - no_comma
+Style/TrailingCommaInLiteral:
+  Description: 'Checks for trailing comma in array and hash literals.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  Enabled: false
 Style/TrivialAccessors:
   Description: Prefer attr_* methods to trivial readers/writers.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#attr_family
@@ -558,11 +557,6 @@ Rails/ActionFilter:
   - filter
   Include:
   - app/controllers/**/*.rb
-Rails/DefaultScope:
-  Description: Checks if the argument passed to default_scope is a block.
-  Enabled: true
-  Include:
-  - app/models/**/*.rb
 Rails/HasAndBelongsToMany:
   Description: Prefer has_many :through to has_and_belongs_to_many.
   Enabled: true
@@ -576,6 +570,11 @@ Rails/Output:
   - config/**/*.rb
   - db/**/*.rb
   - lib/**/*.rb
+  Exclude:
+  - lib/capistrano/**/*.rb
+  - config/deploy.rb
+  - config/deploy/**/*.rb
+  - lib/tasks/**/*.rb
 Rails/ReadWriteAttribute:
   Description: Checks for read_attribute(:attr) and write_attribute(:attr, val).
   Enabled: true
@@ -744,6 +743,7 @@ Style/IndentationConsistency:
 Style/IndentArray:
   Description: Checks the indentation of the first element in an array literal.
   Enabled: true
+  EnforcedStyle: consistent
 Style/InfiniteLoop:
   Description: Use Kernel#loop for infinite loops.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#infinite-loop
@@ -840,9 +840,10 @@ Style/SelfAssignment:
     used.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#self-assignment
   Enabled: false
-Style/SingleSpaceBeforeFirstArg:
-  Description: Checks that exactly one space is used between a method name and the
-    first argument for method calls without parentheses.
+Style/SpaceBeforeFirstArg:
+  Description: >-
+                 Checks that exactly one space is used between a method name
+                 and the first argument for method calls without parentheses.
   Enabled: true
 Style/SpaceAfterColon:
   Description: Use spaces after colons.
@@ -852,8 +853,8 @@ Style/SpaceAfterComma:
   Description: Use spaces after commas.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
   Enabled: true
-Style/SpaceAfterControlKeyword:
-  Description: Use spaces after if/elsif/unless/while/until/case/when.
+Style/SpaceAroundKeyword:
+  Description: 'Use a space around keywords if appropriate.'
   Enabled: true
 Style/SpaceAfterMethodName:
   Description: Do not put a space between a method name and the opening parenthesis
@@ -880,9 +881,6 @@ Style/SpaceBeforeSemicolon:
 Style/SpaceAroundOperators:
   Description: Use spaces around operators.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
-  Enabled: true
-Style/SpaceBeforeModifierKeyword:
-  Description: Put a space before the modifier keyword.
   Enabled: true
 Style/SpaceInsideBrackets:
   Description: No spaces after [ or before ].
@@ -940,6 +938,11 @@ Style/WhileUntilDo:
   Description: Checks for redundant do after while or until.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-multiline-while-do
   Enabled: true
+Style/MultilineMethodCallIndentation:
+  Description: Checks the indentation of the method name part in method calls that span more than one line.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains
+  Enabled: true
+  EnforcedStyle: indented
 Lint/AmbiguousOperator:
   Description: Checks for ambiguous operators in the first argument of a method invocation
     without parentheses.
@@ -1019,10 +1022,6 @@ Lint/ShadowingOuterLocalVariable:
   Description: Do not use the same name as outer local variable for block arguments
     or block local variables.
   Enabled: true
-Lint/SpaceBeforeFirstArg:
-  Description: Put a space between a method name and the first argument in a method
-    call without parentheses.
-  Enabled: true
 Lint/StringConversionInInterpolation:
   Description: Checks for Object#to_s usage in string interpolation.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-to-s
@@ -1063,3 +1062,6 @@ Lint/Void:
 Rails/Delegate:
   Description: Prefer delegate method for delegations.
   Enabled: false
+Rails/TimeZone:
+  Enabled: true
+  EnforcedStyle: flexible


### PR DESCRIPTION
Hemnet's now on Codeclimate platform, so the config needs to align with it.

In addition, this updates `.rubocop.yml` with some of our new conventions (but `Rails` disabled, and a few include/exclude differences).