### PR TITLE
Don't use Wordpress bleeding edge

### DIFF
--- a/spec/docker/Dockerfile
+++ b/spec/docker/Dockerfile
@@ -1,11 +1,5 @@
 FROM appcontainers/wordpress
 
-# Wordpress latest isn't actually the lastest we want to be on the bleeding edge
-RUN rm -rf /var/www/html/
-RUN wget -P /var/www/html/ https://wordpress.org/latest.zip && \
-  unzip /var/www/html/latest.zip -d /var/www/html/ && \
-  rm -fr /var/www/html/latest.zip
-
 # Copy the WP-Config file
 RUN cp /var/www/html/wordpress/wp-config-sample.php /var/www/html/wordpress/wp-config.php
 


### PR DESCRIPTION
Updating Wordpress without updating PHP broke the installation.

Maybe this is not the way you want to move forward, but solves setup for new developers. An alternative would of course be to also make sure PHP version matches the bleeding edge WP requirements. We did not look into that.