### PR TITLE
Allow Faraday major version 1

### DIFF
--- a/wordpress_client.gemspec
+++ b/wordpress_client.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", "~> 0.9"
+  spec.add_dependency "faraday", [">= 0.9", "< 2"]
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
The gem requires `Faraday` version `0.9`, while the latest version of `Faraday` is `1.0.1`. This causes issues when a project that already uses `Faraday` in a later version wants to use `wordpress_client`, and the two versions don't match.

We created a simple fix to allow major version 1, to be able to test out the gem in our environment. However, there might be some Error handling that still needs to be updated, but
we haven't checked properly for that. Therefore we wanted to open an issue, rather than a PR but the feature seems to be turned off for the repo. It would be great if you could allow issues so it's easier to collaborate :)
