### PR TITLE
Resolve test setup

### DIFF
--- a/spec/docker/Dockerfile
+++ b/spec/docker/Dockerfile
@@ -21,6 +21,9 @@ RUN yum clean all
 # base image only contains American timezones
 RUN yum install -y tzdata
 
+RUN yum remove -y php php-common php-cli php-mysql
+RUN yum install -y php56-php php56-php-common php56-php-cli php56-php-mysql
+
 ENV APP_NAME testapp.com
 ENV APACHE_SVRALIAS www.testapp.com localhost
 ENV MYSQL_SERVER localhost

--- a/spec/docker/Dockerfile
+++ b/spec/docker/Dockerfile
@@ -14,6 +14,10 @@ RUN echo "register_meta('post', 'foo', array('type' => 'integer', 'description' 
 RUN echo "register_meta('post', 'bar', array('type' => 'boolean', 'description' => 'Some kind of boolean', 'single' => true, 'show_in_rest' => true));" >>/var/www/html/wordpress/wp-config.php
 RUN echo "register_meta('post', 'baz', array('type' => 'string', 'description' => 'Some kind of string', 'single' => true, 'show_in_rest' => true));" >>/var/www/html/wordpress/wp-config.php
 
+# Resolve broken mirrorfile
+COPY yum.repos.d/CentOS-Base.repo /etc/yum.repos.d/CentOS-Base.repo
+RUN yum clean all
+
 # base image only contains American timezones
 RUN yum install -y tzdata
 

--- a/spec/docker/yum.repos.d/CentOS-Base.repo
+++ b/spec/docker/yum.repos.d/CentOS-Base.repo
@@ -1,0 +1,25 @@
+[base]
+name=CentOS-$releasever - Base
+# mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
+# baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+baseurl=https://vault.centos.org/6.10/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+# released updates
+[updates]
+name=CentOS-$releasever - Updates
+# mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
+# baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+baseurl=https://vault.centos.org/6.10/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+# additional packages that may be useful
+[extras]
+name=CentOS-$releasever - Extras
+# mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra
+# baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+baseurl=https://vault.centos.org/6.10/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6


### PR DESCRIPTION
Hello,

This PR will make our image used in testing last a bit longer. CentOS 6 has reached end of life and the repositories has been moved to centos vault. Also we had to upgrade the PHP version since wordpress now requires 5.6. All tests green after this!

A note, this is a requirement for a safe rollout of #34